### PR TITLE
Fix documentation example for MandrillHelper.put_param/3

### DIFF
--- a/lib/bamboo/adapters/mandrill_helper.ex
+++ b/lib/bamboo/adapters/mandrill_helper.ex
@@ -16,8 +16,8 @@ defmodule Bamboo.MandrillHelper do
   ## Example
 
       email
-      |> put_param(email, "track_opens", true)
-      |> put_param(email, "merge_vars", [
+      |> put_param("track_opens", true)
+      |> put_param("merge_vars", [
         %{
           rcpt: "recipient.email@example.com",
           vars: [
@@ -48,7 +48,7 @@ defmodule Bamboo.MandrillHelper do
   A convenience function for:
 
       email
-      |> put_param(email, "merge_vars", [
+      |> put_param("merge_vars", [
         %{
           rcpt: "user1@example.com",
           vars: [


### PR DESCRIPTION
Thanks for open-sourcing and the work behind bamboo. 
I was perusing the docs and got slightly confused by the example before realising it was an error in the given example.

# Background
The example for Bamboo.MandrillHelper.put_param/3 is incorrectly calling on a non-existent put_param/4
- The example passes email twice to the function
- First through the pipeline
- Second through the function argument

# Fix
This merge request aims to corrects the example in the documentation.